### PR TITLE
Brackets Sprint 22 changes getIndentUnit to getSpaceUnits

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,7 +15,7 @@ define(function (require, exports, module) {
 
     doc.batchOperation(function () {
       var currentLineIndex = 0,
-        tabSize = Editor.getUseTabChar() ? Editor.getTabSize() : Editor.getIndentUnit(),
+        tabSize = Editor.getUseTabChar() ? Editor.getTabSize() : (Editor.getIndentUnit ? Editor.getIndentUnit() : Editor.getSpaceUnits()),
         tabSpaces = new Array(tabSize + 1).join(' '),
         regex,
         match;


### PR DESCRIPTION
As noted in the Brackets Sprint 22 [Release Notes](https://github.com/adobe/brackets/wiki/Release-Notes:-Sprint-22), the `Editor.getIndentUnit/Editor.setIndentUnit` api has been replaced with `Editor.getSpaceUnits/Editor.setSpaceUnits`.

This change fixes the extension for brackets going forward without breaking backwards compatibility.
